### PR TITLE
test(app): enforce renderer↔host IPC boundary (Fixes #67)

### DIFF
--- a/.github/workflows/package-manual.yml
+++ b/.github/workflows/package-manual.yml
@@ -24,4 +24,3 @@ jobs:
     with:
       publish: ${{ inputs.publish }}
       os-matrix: ${{ inputs.os-matrix }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,4 +14,3 @@ jobs:
     with:
       publish: true
       os-matrix: '["ubuntu-latest","macos-latest","windows-latest"]'
-

--- a/packages/app/tests/renderer/ipc-boundary.test.ts
+++ b/packages/app/tests/renderer/ipc-boundary.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+// Renderer ↔ Host boundary test: ensure renderer imports are safe.
+// - Forbid importing Node built-ins and `electron` from the renderer.
+// - Allow React libs and relative imports only.
+
+const RENDERER_DIR = path.join(__dirname, '..', '..', 'src', 'renderer');
+
+function walk(directory: string): string[] {
+  const names = readdirSync(directory);
+  const files: string[] = [];
+  for (const name of names) {
+    const p = path.join(directory, name);
+    const stats = statSync(p);
+    if (stats.isDirectory()) files.push(...walk(p));
+    else if (name.endsWith('.ts') || name.endsWith('.tsx')) files.push(p);
+  }
+  return files;
+}
+
+// Extract module specifiers from simple ESM import statements without heavy parsing.
+function findImports(content: string): string[] {
+  const imports: string[] = [];
+  const lines = content.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('import ')) continue;
+    const re = /['"][^'"]+['"]/;
+    const match = re.exec(trimmed);
+    if (!match) continue;
+    const specifier = match[0].slice(1, -1);
+    imports.push(specifier);
+  }
+  return imports;
+}
+
+const NODE_BUILTINS = new Set([
+  'assert',
+  'buffer',
+  'child_process',
+  'cluster',
+  'crypto',
+  'dgram',
+  'dns',
+  'domain',
+  'events',
+  'fs',
+  'http',
+  'https',
+  'net',
+  'os',
+  'path',
+  'perf_hooks',
+  'process',
+  'punycode',
+  'querystring',
+  'readline',
+  'repl',
+  'stream',
+  'string_decoder',
+  'sys',
+  'timers',
+  'tls',
+  'tty',
+  'url',
+  'util',
+  'v8',
+  'vm',
+  'worker_threads',
+  'zlib',
+  'module',
+]);
+
+function isForbidden(spec: string): boolean {
+  if (spec === 'electron') return true;
+  if (spec.startsWith('node:')) return true;
+  if (NODE_BUILTINS.has(spec)) return true;
+  if (spec.startsWith('aideon_worker')) return true;
+  // Allow react libs and relative imports only
+  if (spec === 'react' || spec.startsWith('react-dom')) return false;
+  if (spec.startsWith('./') || spec.startsWith('../')) return false;
+  // Block any other bare module specifiers to keep surface minimal
+  return true;
+}
+
+describe('renderer IPC boundary', () => {
+  it('renderer files do not import forbidden modules', () => {
+    const files = walk(RENDERER_DIR);
+    const violations: { file: string; imp: string }[] = [];
+    for (const f of files) {
+      const content = readFileSync(f, 'utf8');
+      for (const spec of findImports(content)) {
+        if (isForbidden(spec)) {
+          violations.push({ file: path.relative(process.cwd(), f), imp: spec });
+        }
+      }
+    }
+    const message = violations
+      .map((v) => `- ${v.file}: imports "${v.imp}" (forbidden in renderer)`)
+      .join('\n');
+    expect(violations.length, message).toBe(0);
+  });
+});

--- a/scripts/project-actual-from-pr.mjs
+++ b/scripts/project-actual-from-pr.mjs
@@ -42,12 +42,28 @@ function gql(query) {
 }
 
 function projectId() {
-  const out = gh(['project', 'view', String(PROJECT_NUMBER), '--owner', PROJECT_OWNER, '--format', 'json']);
+  const out = gh([
+    'project',
+    'view',
+    String(PROJECT_NUMBER),
+    '--owner',
+    PROJECT_OWNER,
+    '--format',
+    'json',
+  ]);
   return JSON.parse(out).id;
 }
 
 function fieldIdByName(name) {
-  const out = gh(['project', 'field-list', String(PROJECT_NUMBER), '--owner', PROJECT_OWNER, '--format', 'json']);
+  const out = gh([
+    'project',
+    'field-list',
+    String(PROJECT_NUMBER),
+    '--owner',
+    PROJECT_OWNER,
+    '--format',
+    'json',
+  ]);
   const j = JSON.parse(out);
   const f = (j.fields || j).find((x) => x.name === name);
   return f?.id || null;
@@ -116,4 +132,3 @@ try {
   console.error(`[project-actual-from-pr] ${e.message}`);
   process.exit(2);
 }
-


### PR DESCRIPTION
This PR adds a guard test to enforce the Renderer ↔ Host IPC boundary.

Summary
- Adds `packages/app/tests/renderer/ipc-boundary.test.ts`.
- Scans all `packages/app/src/renderer/**/*.{ts,tsx}` for import specifiers.
- Fails if a renderer file imports `electron`, `node:*`, Node built-ins, or backend modules.
- Allows only React libs and relative imports.

Why
- Codifies AGENTS.md rule: no backend logic in renderer; access via typed preload bridge only.
- Prevents regressions where Node APIs creep into renderer.

Testing
- `yarn test` passes across the suite (incl. this new test).
- `yarn lint` and `yarn typecheck` pass (only expected warnings in test due to fs usage to scan files).

Definition of Done (DoD)
- CI: lint/typecheck/tests pass.
- Security: no renderer HTTP; no new ports; this is test-only.
- Docs: intent captured in the test; no user docs change.

Tracking
- Fixes #67
