### PR TITLE
docs(agents): GitHub Project as tracking source of truth

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -6,14 +6,14 @@ Issues and PRDs for this repo live as GitHub issues in `aideon-ai/aideon-desktop
 
 The project carries structured fields that replace several labels. **Do not apply the replaced labels** — set the project field instead.
 
-| Axis | Project field | Replaces label |
-| ---- | ------------- | -------------- |
-| Lifecycle state | **Status** | `status/*` labels |
-| Work kind | **Kind** | `type/*` labels |
-| Engine module | **Module** | `module/*` labels |
-| Primary area | **Area** | primary `area/*` label |
-| Scheduling weight | **Priority** | `priority/*` labels |
-| Triage state | **Triage** | — (mirrors triage label; keep both in sync) |
+| Axis              | Project field | Replaces label                              |
+| ----------------- | ------------- | ------------------------------------------- |
+| Lifecycle state   | **Status**    | `status/*` labels                           |
+| Work kind         | **Kind**      | `type/*` labels                             |
+| Engine module     | **Module**    | `module/*` labels                           |
+| Primary area      | **Area**      | primary `area/*` label                      |
+| Scheduling weight | **Priority**  | `priority/*` labels                         |
+| Triage state      | **Triage**    | — (mirrors triage label; keep both in sync) |
 
 Labels still applied to issues (not replaced by project fields):
 
@@ -25,14 +25,14 @@ Labels still applied to issues (not replaced by project fields):
 
 **Status** (lifecycle — driven by project automations; update manually when needed):
 
-| Value | Meaning |
-| ----- | ------- |
-| Todo | In the queue, not started |
-| In Progress | Being actively worked |
-| In Review | PR open, awaiting review |
-| Blocked | Waiting on a dependency or reviewer action |
-| Deferred | Intentionally postponed |
-| Done | Closed / merged |
+| Value       | Meaning                                    |
+| ----------- | ------------------------------------------ |
+| Todo        | In the queue, not started                  |
+| In Progress | Being actively worked                      |
+| In Review   | PR open, awaiting review                   |
+| Blocked     | Waiting on a dependency or reviewer action |
+| Deferred    | Intentionally postponed                    |
+| Done        | Closed / merged                            |
 
 **Kind:** `feature` · `task` · `chore` · `docs` · `decision` · `bug`
 
@@ -46,16 +46,16 @@ Labels still applied to issues (not replaced by project fields):
 
 ## Project automations (do not manually override unless correcting an error)
 
-| Trigger | Status set to |
-| ------- | ------------- |
-| Item added to project | Todo |
-| PR opened / ready for review | In Review |
-| Review requests changes | Blocked |
-| Review approved | In Progress |
-| Issue or PR closed | Done |
-| PR merged | Done |
-| Item reopened | Todo |
-| Closed item not updated for 2 weeks | Archived |
+| Trigger                             | Status set to |
+| ----------------------------------- | ------------- |
+| Item added to project               | Todo          |
+| PR opened / ready for review        | In Review     |
+| Review requests changes             | Blocked       |
+| Review approved                     | In Progress   |
+| Issue or PR closed                  | Done          |
+| PR merged                           | Done          |
+| Item reopened                       | Todo          |
+| Closed item not updated for 2 weeks | Archived      |
 
 ## Conventions
 
@@ -115,7 +115,7 @@ Run `gh issue view <number> --comments`.
 
 ## Related documents
 
-| Document | What it covers |
-| -------- | -------------- |
-| [triage-labels.md](./triage-labels.md) | The five triage roles and the one-at-a-time state machine. |
-| [domain.md](./domain.md) | How to orient in the repo and use the project's vocabulary in issue text. |
+| Document                               | What it covers                                                            |
+| -------------------------------------- | ------------------------------------------------------------------------- |
+| [triage-labels.md](./triage-labels.md) | The five triage roles and the one-at-a-time state machine.                |
+| [domain.md](./domain.md)               | How to orient in the repo and use the project's vocabulary in issue text. |

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,15 +1,72 @@
 # Issue tracker: GitHub
 
-Issues and PRDs for this repo live as GitHub issues in `aideon-ai/aideon-desktop`. Use the `gh` CLI for all operations; it infers the repo from `git remote -v` when run inside a clone.
+Issues and PRDs for this repo live as GitHub issues in `aideon-ai/aideon-desktop`, tracked on the **GitHub Project** at `https://github.com/orgs/aideon-ai/projects/1`. Use the `gh` CLI for all operations; it infers the repo from `git remote -v` when run inside a clone.
+
+## The project is the source of truth for workflow state
+
+The project carries structured fields that replace several labels. **Do not apply the replaced labels** — set the project field instead.
+
+| Axis | Project field | Replaces label |
+| ---- | ------------- | -------------- |
+| Lifecycle state | **Status** | `status/*` labels |
+| Work kind | **Kind** | `type/*` labels |
+| Engine module | **Module** | `module/*` labels |
+| Primary area | **Area** | primary `area/*` label |
+| Scheduling weight | **Priority** | `priority/*` labels |
+| Triage state | **Triage** | — (mirrors triage label; keep both in sync) |
+
+Labels still applied to issues (not replaced by project fields):
+
+- **Triage labels** (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) — keep on issues; agents and humans filter by label, not by project field. See [triage-labels.md](./triage-labels.md).
+- **`area/*`** — apply all relevant areas as labels; the project Area field holds only the primary one.
+- **`released`** — release marker; not a project field.
+
+## Project field values
+
+**Status** (lifecycle — driven by project automations; update manually when needed):
+
+| Value | Meaning |
+| ----- | ------- |
+| Todo | In the queue, not started |
+| In Progress | Being actively worked |
+| In Review | PR open, awaiting review |
+| Blocked | Waiting on a dependency or reviewer action |
+| Deferred | Intentionally postponed |
+| Done | Closed / merged |
+
+**Kind:** `feature` · `task` · `chore` · `docs` · `decision` · `bug`
+
+**Module:** `praxis` · `mneme` · `chrona` · `metis` · `continuum` · `host` · `renderer`
+
+**Area:** `ui` · `api` · `time` · `analytics` · `ci` · `security` · `rpc` · `adapters` · `integration` · `worker` · `automation` · `server` · `finance` · `cloud` · `docs` · `extensibility` · `governance` · `perf` · `platform`
+
+**Priority:** `P0` · `P1` · `P2` · `P3`
+
+**Triage:** mirrors the triage label — `needs-triage` · `needs-info` · `ready-for-agent` · `ready-for-human` · `wontfix`
+
+## Project automations (do not manually override unless correcting an error)
+
+| Trigger | Status set to |
+| ------- | ------------- |
+| Item added to project | Todo |
+| PR opened / ready for review | In Review |
+| Review requests changes | Blocked |
+| Review approved | In Progress |
+| Issue or PR closed | Done |
+| PR merged | Done |
+| Item reopened | Todo |
+| Closed item not updated for 2 weeks | Archived |
 
 ## Conventions
 
 - **Create an issue:** `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
 - **Read an issue:** `gh issue view <number> --comments`.
-- **List issues:** `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with `--label` and `--state` filters as needed.
+- **List issues:** `gh issue list --state open --json number,title,body,labels --jq '[.[] | {number, title, labels: [.labels[].name]}]'` with `--label` and `--state` filters as needed.
+- **Find agent-ready work:** `gh issue list --label ready-for-agent --state open`
 - **Comment:** `gh issue comment <number> --body "..."`
 - **Apply / remove labels:** `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
 - **Close:** `gh issue close <number> --comment "..."`
+- **Set a project field:** use the GraphQL `updateProjectV2ItemFieldValue` mutation (project id `PVT_kwDOD2wE0s4BOFEd`).
 
 ## Issue templates
 
@@ -18,57 +75,39 @@ New issues created through the GitHub UI use the forms in `.github/ISSUE_TEMPLAT
 - `bug_report.yml` — auto-applies `type/bug`; fields: what happened, app version, steps, logs.
 - `feature_request.yml` — auto-applies `type/feature`; fields: problem statement, proposed solution, rationale/trade-offs.
 
-When creating issues via `gh`, mirror these shapes (a bug body covers what happened / version / steps / logs) and apply the matching `type/*` label yourself, since `gh` does not run the template automation.
+When creating issues via `gh`, mirror these shapes and apply the triage label plus `area/*` labels; the project fields (Kind, Priority, Module, Area, Status) are set separately or via automation.
 
-## Label taxonomy (apply contextual labels, not just triage state)
+## Label guidance (what still goes on issues)
 
-This repo carries a structured label set. When you create or triage an issue, apply the labels that fit — **in addition to** the triage-state label from [triage-labels.md](./triage-labels.md):
-
-- **`type/*`** — `type/feature`, `type/task`, `type/chore`, `type/docs`, `type/decision` (and `type/bug` via the bug template). One per issue.
-- **`area/*`** — `platform`, `ci`, `security`, `rpc`, `adapters`, `ui`, `integration`, `worker`, `analytics`, `time`, `api`, `automation`, `server`, `finance`, `cloud`, `docs`, `extensibility`, `governance`, `perf`. One or more.
-- **`module/*`** — `praxis`, `continuum`, `chrona`, `metis` (the engine crates). Apply when the work clearly lives in one engine.
-- **`priority/*`** — `priority/P1`, `priority/P2`, `priority/P3`.
-- **`status/*`** — `status/todo`, `status/blocked`, `status/in-progress`, `status/done` (lifecycle, distinct from triage state).
-
-Prefer reusing an existing label over inventing one. Run `gh label list --limit 100` to see the current set before adding anything new.
-
-### Label-combination guidance
-
-A well-labelled issue carries one triage label, one `type/*`, one or more `area/*`, optionally a `module/*` and a `priority/*`, and a lifecycle `status/*`. The four axes — triage state, type, context (area/module), and lifecycle status — are orthogonal and co-applied. Worked examples:
+Apply the triage label plus all relevant `area/*` labels. Everything else goes in the project fields.
 
 ```sh
-# A specified analytics bug an agent can take, medium priority, not yet started
+# Agent-ready analytics bug, two areas
 gh issue create --title "Betweenness centrality drops isolated nodes" \
   --body "..." \
-  --label "ready-for-agent,type/bug,area/analytics,module/metis,priority/P2,status/todo"
+  --label "ready-for-agent,area/analytics,area/api"
+# Then set project fields: Kind=bug, Module=metis, Priority=P2, Status=Todo
 
-# A docs task needing human judgement, blocked on a pending decision
+# Docs task needing human judgement
 gh issue edit 530 \
   --remove-label "needs-triage" \
-  --add-label "ready-for-human,type/docs,area/docs,status/blocked"
-
-# A cross-cutting feature spanning two areas
-gh issue edit 544 \
-  --add-label "type/feature,area/ui,area/rpc,priority/P1"
+  --add-label "ready-for-human,area/docs"
+# Then set project field: Triage=ready-for-human
 ```
-
-Keep the lifecycle `status/*` current as work moves (`status/todo` → `status/in-progress` → `status/done`); it changes independently of the triage label.
 
 ## Issue-linking conventions
 
-Express relationships between issues so the graph is navigable rather than narrated:
+- **Close-on-merge:** put `Closes #NNN` in a PR body so merging closes the issue.
+- **Reference without closing:** mention `#NNN` in a body or comment for "related to" / "follow-up of".
+- **Parent / sub-issues:** keep a checklist of `- [ ] #NNN` in the parent issue body; GitHub renders it as sub-issue progress.
+- **Blocked-by:** state `Blocked by #NNN` in the body; the automation sets Status to Blocked when a review requests changes; set it manually for issue-level blockers.
+- **Duplicates:** comment `Duplicate of #NNN`, close the newer issue.
 
-- **Close-on-merge:** put `Closes #NNN` (or `Fixes #NNN`) in a PR body so merging the PR closes the issue. Use `Closes` for the issue a PR fully resolves.
-- **Reference without closing:** mention `#NNN` in a body or comment to link two issues without auto-closing — for "related to", "follow-up of", or "see also".
-- **Parent / sub-issues:** for a tracked breakdown, keep a checklist of `- [ ] #NNN` task references in the parent (epic/PRD) issue; GitHub renders these as a sub-issue progress list.
-- **Blocked-by:** state the blocker explicitly in the body (`Blocked by #NNN`) and apply `status/blocked`; clear both once the blocker closes.
-- **Duplicates:** comment `Duplicate of #NNN`, close the newer issue, and keep discussion on the original.
-
-Always reference by `#NNN` rather than a pasted URL, so the cross-link renders and back-links appear on both issues.
+Always reference by `#NNN`, not a pasted URL.
 
 ## When a skill says "publish to the issue tracker"
 
-Create a GitHub issue.
+Create a GitHub issue and set the relevant project fields.
 
 ## When a skill says "fetch the relevant ticket"
 
@@ -76,7 +115,7 @@ Run `gh issue view <number> --comments`.
 
 ## Related documents
 
-| Document                               | What it covers                                                            |
-| -------------------------------------- | ------------------------------------------------------------------------- |
-| [triage-labels.md](./triage-labels.md) | The five triage roles and the one-at-a-time state machine.                |
-| [domain.md](./domain.md)               | How to orient in the repo and use the project's vocabulary in issue text. |
+| Document | What it covers |
+| -------- | -------------- |
+| [triage-labels.md](./triage-labels.md) | The five triage roles and the one-at-a-time state machine. |
+| [domain.md](./domain.md) | How to orient in the repo and use the project's vocabulary in issue text. |


### PR DESCRIPTION
## Summary

- Updates `docs/agents/issue-tracker.md` to reflect the GitHub Project (project 1) as the primary workflow surface
- Documents all six project fields (Status, Kind, Module, Area, Priority, Triage) and which labels they replace
- Lists what still goes on issues: triage labels, all `area/*` labels, `released`
- Adds project automation table so agents don't fight the workflows
- Updates examples and guidance to the new pattern

## What was done alongside this PR (project setup, not in code)

- Removed 278 legacy `aideon-platform` items from the project
- Added Triage, Kind, Module, Area custom fields (single-select)
- Renamed Status options to match `status/*` labels; added In Review
- Populated all fields from existing issue labels across 100 items
- Applied triage labels to all 72 open issues; synced Triage project field

## Test plan

- [ ] Read `docs/agents/issue-tracker.md` — field table, automation table, and examples are clear
- [ ] Create a test issue via `gh issue create` following the new guidance; verify project fields populate correctly via automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)