### PR TITLE
fix(release): switch release-please to simple type (unblock releases)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "rust",
+      "release-type": "simple",
       "package-name": "aideon-desktop",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,


### PR DESCRIPTION
## Problem
Every `release-please` run fails before opening a PR:
```
release-please failed: value at path package.version is not tagged
```
The `rust` release-type requires each crate's `Cargo.toml` to carry a concrete `[package] version`, but all six crates use `version.workspace = true`. In workspace mode it also unconditionally tries to update the **virtual** root `Cargo.toml` (which has no `[package]`), throwing `is not a package manifest`. Confirmed by reading the updater source (`updaters/rust/cargo-toml.js`) and the strategy (`strategies/rust.js:80`).

## Fix
The Rust crate versions are build-internal and irrelevant to the release artifact — **Tauri takes the app/bundle version from `tauri.conf.json`, not `Cargo.toml`**. So drive the release purely off the user-facing version files via the **`simple`** release-type. It updates the existing `extra-files` (`package.json`, `src-tauri/tauri.conf.json`, `src/version.ts`) and touches no Cargo files, so `--locked` stays valid and there's no Cargo.lock churn. One-line config change.

## Verified
`release-please release-pr --dry-run` against this branch: no errors, **"Would open 1 pull request"**, updates only the three version files. (Alternatives rejected: per-crate concrete versions + Cargo.lock-sync workflow — far more surface for no user-visible benefit, since the bundle version is `tauri.conf.json`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)