### PR TITLE
fix(ci): unblock main — sonarjs 4 lint errors + prettier-ignore release files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -15,3 +15,9 @@ src/design-system/components/**
 docs/contracts/ipc-manifest.json
 docs/contracts/event-manifest.json
 docs/contracts/shell-command-manifest.json
+
+# Rewritten by release-please on every release PR in its own style (e.g. it
+# expands `"capabilities": ["default"]` to a multi-line array prettier rejects).
+# The tool owns these files' shape; format-checking them just breaks releases.
+CHANGELOG.md
+src-tauri/tauri.conf.json

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -106,6 +106,14 @@ export default defineConfig([
 
   // Sonar-style code quality and complexity
   sonarjs.configs.recommended,
+  {
+    rules: {
+      // `redundant-type-aliases` (new in sonarjs 4) rejects `type ScenarioKey = string`,
+      // but our DTO aliases (ScenarioKey, ConfidencePercent, …) are deliberate domain
+      // types — semantic names, not structural shortcuts. `no-redundant-optional` stays on.
+      'sonarjs/redundant-type-aliases': 'off',
+    },
+  },
 
   // Security hotspot checks (not taint analysis, but still valuable)
   security.configs.recommended,

--- a/src/dtos/temporal.ts
+++ b/src/dtos/temporal.ts
@@ -1,8 +1,8 @@
 import type { IsoDateTime } from './iso';
 import type { Layer } from './mneme';
 
-export type ScenarioKey = string | undefined;
-export type ConfidencePercent = number | undefined;
+export type ScenarioKey = string;
+export type ConfidencePercent = number;
 
 export interface GraphSnapshotMetrics {
   nodeCount: number;

--- a/src/engines/praxis/components/dashboard/meta-model-panel.tsx
+++ b/src/engines/praxis/components/dashboard/meta-model-panel.tsx
@@ -280,7 +280,7 @@ function MetaModelEntryCard({
 function AttributesList({
   attributes,
 }: {
-  readonly attributes?: MetaModelSchema['types'][number]['attributes'];
+  readonly attributes?: NonNullable<MetaModelSchema['types'][number]['attributes']>;
 }) {
   if (!attributes || attributes.length === 0) {
     return <p className="text-muted-foreground pt-2 text-xs">No attributes defined.</p>;


### PR DESCRIPTION
Two issues are currently blocking **everything** (main's `node:lint` is red, and the autorelease PR #311 can't pass):

## 1. main lint is red after the sonarjs major bump (#299)
Dependabot #299 bumped `eslint-plugin-sonarjs` 3.0.7 → **4.1.0**, whose new rules produce 7 errors on existing code — so `node:lint` fails on main and every branch off it.
- `no-redundant-optional`: DTO aliases `ScenarioKey`/`ConfidencePercent` were `string | undefined` / `number | undefined`, making `scenario?: ScenarioKey` a redundant `?` + `| undefined`. Dropped `| undefined` (all uses are optional props; none needed the union); wrapped one indexed-access prop in `NonNullable<…>`.
- `redundant-type-aliases` (also new) then rejects `type ScenarioKey = string` — but these are deliberate **domain types**. Turned that one rule off in config (same pattern as the existing react-hooks bailout overrides). `no-redundant-optional` stays enforced.

## 2. autorelease PR fails format:check
release-please rewrites `CHANGELOG.md` and `src-tauri/tauri.conf.json` in its own style (expands `"capabilities": ["default"]` to a multi-line array prettier reformats). Both are clean on main, so the gate only fails on release PRs → blocks every release. Prettier-ignored them (same treatment as the generated manifests / `version.ts`).

## Verified
`pnpm run node:ci` fully green: lint, typecheck, 267 tests, format.

## Effect
Merging greens main. release-please will then update **#311** against the new main → #311's checks pass → 0.3.0 is mergeable. #309 also unblocks once rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)