### PR TITLE
fix(build): drop AppImage from bundle targets (de-flake release builds)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["deb", "rpm", "app", "dmg", "msi", "nsis"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
`bundle.targets: "all"` builds AppImage on Linux, which **downloads `linuxdeploy` + the AppImage runtime from the network at bundle time**. That already flaked once on a runner DNS hiccup, and would hit every real release via `reusable-release.yml`.

Pin an explicit target list — `["deb", "rpm", "app", "dmg", "msi", "nsis"]` — so no bundle step needs a network download. Tauri builds the applicable ones per-OS: deb + rpm on Linux, app + dmg on macOS, msi + nsis on Windows. deb + rpm cover the mainstream Linux package managers; AppImage can be restored later if portable-format distribution is wanted.

Verified: config parses, `tauri info` loads it, `pnpm run ci` green (pre-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)