### PR TITLE
chore(dev):  pip configuration from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-  - package-ecosystem: 'pip'
-    directory: '/packages/worker'
-    schedule:
-      interval: 'weekly'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
Removed pip package ecosystem configuration from Dependabot.

## Summary

Describe the change. Link to issues/ADRs. Use Conventional Commits in title.

## Checklist

- [ ] Follows AGENTS.md boundaries and security posture
- [ ] Tests updated/added and passing
- [ ] Lint/format pass (JS + Python)
- [ ] No renderer HTTP; no open TCP ports in desktop mode
- [ ] PII redaction unaffected

## Screenshots / Logs

If applicable.
