### PR TITLE
docs(build-contracts): golden journey as a per-milestone growing CI gate

### DIFF
--- a/docs/build-contracts/golden-journey.md
+++ b/docs/build-contracts/golden-journey.md
@@ -82,6 +82,21 @@ All steps run against the seed metamodel [`core-v1.json`](../data/meta/core-v1.j
 
 A build is **golden-journey-complete** when every step runs against the seed data, every command resolves in the IPC manifest, and every oracle fixture exists and matches. Until then, each _(oracle: planned)_ marker is a tracked build-contract item, not a silent gap.
 
+### Executable extension schedule (the journey is a growing gate, not a big-bang at M3)
+
+The journey runs **as an executable CI gate from M0 onward** — each milestone wires **its own slice** into the same running journey rather than waiting for M3. Each milestone's in-window exit-gate issue _is_ the wiring of its slice; the umbrella tracker is [#326].
+
+| Milestone | Adds to the executable journey                                                                 | Wired by                    |
+| --------- | ---------------------------------------------------------------------------------------------- | --------------------------- |
+| **M0**    | Steps 1, 8, 9, 10 — create/open, close/reopen, wipe `.aideon/runtime/`, rebuild + equivalence. | host-boundary gate #319     |
+| **M1**    | Steps 2, 3 — create an entity + relationship; an invalid write is refused, never an op.        | authoring in-window #348    |
+| **M2**    | Steps 4, 5, 6 — plan/actual claims at different valid times; resolve two viewpoints; diff.     | time-control in-window #352 |
+| **M3**    | Step 7 — a catalogue artefact executes and renders deterministically.                          | (M3 catalogue gate)         |
+
+The slice a milestone adds is part of **that milestone's exit gate** — a milestone is not "done" until its golden-journey steps run green in the assembled app. No slice waits for a later milestone to become executable.
+
+[#326]: https://github.com/aideon-ai/aideon-desktop/issues/326
+
 ---
 
 ## Related documents


### PR DESCRIPTION
## What

Gate 5 of the M1/M2 grill pack. Makes explicit that the golden journey runs as an **executable CI gate from M0 onward** — each milestone wires **its own slice** into the same running journey, rather than the whole thing becoming executable only at M3.

Adds an "Executable extension schedule" to `golden-journey.md` mapping each milestone's slice to the in-window exit-gate issue that wires it:

| Milestone | Steps | Wired by |
|---|---|---|
| M0 | 1, 8, 9, 10 | #319 |
| M1 | 2, 3 | #348 |
| M2 | 4, 5, 6 | #352 |
| M3 | 7 | (M3 catalogue gate) |

A milestone is not "done" until its golden-journey slice runs green in the assembled app. #326 is the umbrella tracker (updated).

## Part of the M1/M2 issue-pack assembly
This PR is the doc half; the issues created alongside it:
- **M1 split:** #346 effective-schema compiler → #347 validation boundary → #348 authoring in-window (chain head: #343).
- **M2 vector-first split:** #243 Viewpoint → #349 resolver+state-at → {#350 scenario, #351 diff} → #352 host commands + time-control in-window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDfBw4QGj4s3FPG7GYTBhX