### PR TITLE
chore: re-sync generated next-env.d.ts (stop the recurring dirty-tree drift)

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## What
`next-env.d.ts` is Next-generated (`// should not be edited`). The committed form was stale — it imported `./.next/dev/types/routes.d.ts` while the installed Next regenerates `./.next/types/routes.d.ts` — so it showed dirty on every checkout/pull. This commits the regenerated form to stop the drift.

## Why not gitignore
It's in `tsconfig.json` `include` and supplies Next's ambient type references, and `node:ci` runs `tsc --noEmit` with **no `next build` first** (`pipeline.yml:57`) — gitignoring it would break typecheck on a fresh checkout. It's already in `.prettierignore`. Next's own guidance is to commit this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDfBw4QGj4s3FPG7GYTBhX