### PR TITLE
feat(host): collapse the command envelope into one tested adapter (#357)

### DIFF
--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -118,6 +118,14 @@ impl<T> IpcResponse<T> {
     }
 }
 
+/// Recognise an engine error meaning "the derived snapshot does not exist yet"
+/// — absence, not failure. Callers (scene, workspace) treat it as an empty
+/// result. One predicate so detection lives in a single place rather than being
+/// re-implemented per command module.
+pub(crate) fn is_missing_snapshot_error(message: &str) -> bool {
+    message.contains("os error 2") || message.contains("No such file")
+}
+
 pub async fn ipc_handle<T, Fut>(request_id: String, fut: Fut) -> IpcResponse<T>
 where
     Fut: Future<Output = Result<T, HostError>>,

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -7,7 +7,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::fmt;
-use std::future::Future;
 
 /// Stable error envelope returned by host commands.
 ///
@@ -124,16 +123,6 @@ impl<T> IpcResponse<T> {
 /// re-implemented per command module.
 pub(crate) fn is_missing_snapshot_error(message: &str) -> bool {
     message.contains("os error 2") || message.contains("No such file")
-}
-
-pub async fn ipc_handle<T, Fut>(request_id: String, fut: Fut) -> IpcResponse<T>
-where
-    Fut: Future<Output = Result<T, HostError>>,
-{
-    match fut.await {
-        Ok(result) => IpcResponse::ok(request_id, result),
-        Err(err) => IpcResponse::err(request_id, err),
-    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/praxis_api/commands.rs
+++ b/src-tauri/src/praxis_api/commands.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use tauri::State;
 
 use crate::ipc::{EmptyPayload, HostError, IpcRequest, IpcResponse};
+use crate::telemetry::command_envelope;
 use crate::worker::WorkerState;
 
 const DEFAULT_BRANCH: &str = "main";
@@ -86,11 +87,10 @@ async fn praxis_artefact_execute_graph_inner(
     engine: &TemporalEngine,
     request: IpcRequest<GraphViewDefinition>,
 ) -> IpcResponse<GraphViewModel> {
-    let request_id = request.request_id;
-    match praxis_graph_view_inner(engine, request.payload).await {
-        Ok(result) => IpcResponse::ok(request_id, result),
-        Err(err) => IpcResponse::err(request_id, err),
-    }
+    command_envelope("praxis_artefact_execute_graph", request, |definition| {
+        praxis_graph_view_inner(engine, definition)
+    })
+    .await
 }
 
 async fn praxis_catalogue_view_inner(
@@ -111,11 +111,10 @@ async fn praxis_artefact_execute_catalogue_inner(
     engine: &TemporalEngine,
     request: IpcRequest<CatalogueViewDefinition>,
 ) -> IpcResponse<CatalogueViewModel> {
-    let request_id = request.request_id;
-    match praxis_catalogue_view_inner(engine, request.payload).await {
-        Ok(result) => IpcResponse::ok(request_id, result),
-        Err(err) => IpcResponse::err(request_id, err),
-    }
+    command_envelope("praxis_artefact_execute_catalogue", request, |definition| {
+        praxis_catalogue_view_inner(engine, definition)
+    })
+    .await
 }
 
 async fn praxis_matrix_view_inner(
@@ -136,11 +135,10 @@ async fn praxis_artefact_execute_matrix_inner(
     engine: &TemporalEngine,
     request: IpcRequest<MatrixViewDefinition>,
 ) -> IpcResponse<MatrixViewModel> {
-    let request_id = request.request_id;
-    match praxis_matrix_view_inner(engine, request.payload).await {
-        Ok(result) => IpcResponse::ok(request_id, result),
-        Err(err) => IpcResponse::err(request_id, err),
-    }
+    command_envelope("praxis_artefact_execute_matrix", request, |definition| {
+        praxis_matrix_view_inner(engine, definition)
+    })
+    .await
 }
 
 async fn praxis_chart_view_inner(
@@ -161,11 +159,10 @@ async fn praxis_artefact_execute_chart_inner(
     engine: &TemporalEngine,
     request: IpcRequest<ChartViewDefinition>,
 ) -> IpcResponse<ChartViewModel> {
-    let request_id = request.request_id;
-    match praxis_chart_view_inner(engine, request.payload).await {
-        Ok(result) => IpcResponse::ok(request_id, result),
-        Err(err) => IpcResponse::err(request_id, err),
-    }
+    command_envelope("praxis_artefact_execute_chart", request, |definition| {
+        praxis_chart_view_inner(engine, definition)
+    })
+    .await
 }
 
 async fn praxis_apply_operations_inner(
@@ -214,17 +211,10 @@ async fn praxis_task_apply_operations_inner(
     engine: &TemporalEngine,
     request: IpcRequest<ApplyOperationsPayload>,
 ) -> IpcResponse<OperationBatchResult> {
-    let request_id = request.request_id;
-    match praxis_apply_operations_inner(
-        engine,
-        request.payload.operations,
-        request.payload.branch,
-    )
+    command_envelope("praxis_task_apply_operations", request, |payload| {
+        praxis_apply_operations_inner(engine, payload.operations, payload.branch)
+    })
     .await
-    {
-        Ok(result) => IpcResponse::ok(request_id, result),
-        Err(err) => IpcResponse::err(request_id, err),
-    }
 }
 
 pub(crate) async fn praxis_list_scenarios_inner(
@@ -247,11 +237,10 @@ async fn praxis_scenario_list_inner(
     engine: &TemporalEngine,
     request: IpcRequest<EmptyPayload>,
 ) -> IpcResponse<Vec<ScenarioSummary>> {
-    let request_id = request.request_id;
-    match praxis_list_scenarios_inner(engine).await {
-        Ok(result) => IpcResponse::ok(request_id, result),
-        Err(err) => IpcResponse::err(request_id, err),
-    }
+    command_envelope("praxis_scenario_list", request, |_payload| {
+        praxis_list_scenarios_inner(engine)
+    })
+    .await
 }
 
 async fn resolve_snapshot(
@@ -290,9 +279,11 @@ fn change_set_from_operations(
                 let existing = snapshot
                     .node(&node.id)
                     .ok_or_else(|| HostError::invalid_input("node missing for update"))?;
-                let node_type = node.r#type.clone().or_else(|| existing.r#type.clone()).ok_or_else(
-                    || HostError::invalid_input("node type is required"),
-                )?;
+                let node_type = node
+                    .r#type
+                    .clone()
+                    .or_else(|| existing.r#type.clone())
+                    .ok_or_else(|| HostError::invalid_input("node type is required"))?;
                 let merged_props = merge_props(existing.props.clone(), node.props);
                 changes.node_updates.push(NodeVersion {
                     id: node.id,
@@ -320,9 +311,11 @@ fn change_set_from_operations(
             PraxisOperation::UpdateEdge { edge } => {
                 let existing = find_edge(snapshot, edge.id.as_deref(), &edge.from, &edge.to)
                     .ok_or_else(|| HostError::invalid_input("edge missing for update"))?;
-                let edge_type = edge.r#type.clone().or_else(|| existing.r#type.clone()).ok_or_else(
-                    || HostError::invalid_input("edge type is required"),
-                )?;
+                let edge_type = edge
+                    .r#type
+                    .clone()
+                    .or_else(|| existing.r#type.clone())
+                    .ok_or_else(|| HostError::invalid_input("edge type is required"))?;
                 let merged_props = merge_props(existing.props.clone(), edge.props);
                 changes.edge_updates.push(EdgeVersion {
                     id: edge.id.or_else(|| existing.id.clone()),

--- a/src-tauri/src/scene.rs
+++ b/src-tauri/src/scene.rs
@@ -7,7 +7,7 @@ use aideon_praxis::praxis::graph_layout::{GraphLayoutGetRequest, GraphLayoutSave
 use log::info;
 use serde::Deserialize;
 
-use crate::ipc::{HostError, IpcRequest, IpcResponse};
+use crate::ipc::{HostError, IpcRequest, IpcResponse, is_missing_snapshot_error};
 
 /// Return a raw scene for the canvas. The renderer performs layout when needed.
 #[tauri::command]
@@ -136,10 +136,6 @@ fn canvas_snapshot_base() -> Result<std::path::PathBuf, HostError> {
     Ok(dirs::data_dir()
         .ok_or_else(|| HostError::internal("no data dir"))?
         .join("AideonPraxis"))
-}
-
-fn is_missing_snapshot_error(message: &str) -> bool {
-    message.contains("os error 2") || message.contains("No such file")
 }
 
 /// Persist a canvas layout snapshot (geometry, z-order, grouping) for a document and asOf.

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -130,6 +130,43 @@ where
     }
 }
 
+/// The one command envelope: unpack the request, stamp `correlation_id` +
+/// telemetry, run the handler, wrap success, and map errors to the stable IPC
+/// envelope. Every host command delegates through this so envelope behaviour
+/// lives in one place. Internal/unclassified errors are redacted on the way
+/// out; known domain errors keep their stable code and safe message.
+pub async fn command_envelope<Req, Res, F, Fut>(
+    command: &'static str,
+    request: IpcRequest<Req>,
+    handler: F,
+) -> IpcResponse<Res>
+where
+    F: FnOnce(Req) -> Fut,
+    Fut: Future<Output = Result<Res, HostError>>,
+{
+    let correlation_id = request.request_id.clone();
+    match record_command(command, &correlation_id, handler(request.payload)).await {
+        Ok(payload) => IpcResponse::ok(correlation_id, payload),
+        // `record_command` has already logged the raw error; redact before it
+        // crosses the boundary so internal detail never reaches the renderer.
+        Err(error) => IpcResponse::err(correlation_id, redact_external(error)),
+    }
+}
+
+/// Stable, non-sensitive message returned for internal/unclassified errors.
+const INTERNAL_ERROR_MESSAGE: &str = "An internal error occurred.";
+
+/// Redact an error for the renderer. Known, user-actionable errors keep their
+/// stable code and safe message; internal/unclassified errors keep their code
+/// but get a generic message — the raw detail stays in the logs only.
+fn redact_external(error: HostError) -> HostError {
+    if error.code == "internal_error" {
+        HostError::new(error.code, INTERNAL_ERROR_MESSAGE)
+    } else {
+        error
+    }
+}
+
 pub async fn respond_with_request<P, ResultType, Handler, HandlerFuture>(
     command: &'static str,
     request: IpcRequest<P>,
@@ -139,12 +176,7 @@ where
     Handler: FnOnce(P) -> HandlerFuture,
     HandlerFuture: Future<Output = Result<ResultType, HostError>>,
 {
-    let correlation_id = request.request_id.clone();
-    let record = record_command(command, &correlation_id, handler(request.payload)).await;
-    match record {
-        Ok(payload) => Ok(IpcResponse::ok(correlation_id, payload)),
-        Err(error) => Ok(IpcResponse::err(correlation_id, error)),
-    }
+    Ok(command_envelope(command, request, handler).await)
 }
 
 #[tauri::command]
@@ -197,6 +229,77 @@ mod telemetry_tests {
 
         assert_eq!(response.status, "ok");
         assert_eq!(response.result, Some(7));
+    }
+
+    #[tokio::test]
+    async fn command_envelope_wraps_success_and_echoes_request_id() {
+        let request = IpcRequest {
+            request_id: "req-1".to_string(),
+            payload: "payload".to_string(),
+        };
+
+        let response: IpcResponse<usize> =
+            command_envelope("envelope_success", request, |payload: String| async move {
+                Ok::<usize, HostError>(payload.len())
+            })
+            .await;
+
+        assert_eq!(response.status, "ok");
+        assert_eq!(response.result, Some(7));
+        assert_eq!(response.request_id, "req-1");
+    }
+
+    #[tokio::test]
+    async fn command_envelope_preserves_known_domain_error() {
+        let request = IpcRequest {
+            request_id: "req-e".to_string(),
+            payload: (),
+        };
+
+        let response: IpcResponse<()> =
+            command_envelope("envelope_known_err", request, |_: ()| async move {
+                Err::<(), HostError>(HostError::invalid_time("as_of is in the future"))
+            })
+            .await;
+
+        assert_eq!(response.status, "error");
+        let error = response.error.expect("error payload");
+        assert_eq!(error.code, "invalid_time");
+        // Known, user-actionable error: message preserved, never redacted.
+        assert_eq!(error.message, "as_of is in the future");
+    }
+
+    #[tokio::test]
+    async fn command_envelope_redacts_internal_error_message() {
+        let request = IpcRequest {
+            request_id: "req-i".to_string(),
+            payload: (),
+        };
+
+        let response: IpcResponse<()> =
+            command_envelope("envelope_internal", request, |_: ()| async move {
+                Err::<(), HostError>(HostError::internal(
+                    "sqlite error at /Users/secret/db.sqlite: disk I/O failed",
+                ))
+            })
+            .await;
+
+        assert_eq!(response.status, "error");
+        let error = response.error.expect("error payload");
+        assert_eq!(error.code, "internal_error");
+        // Raw internal detail must not reach the renderer.
+        assert!(
+            !error.message.contains("/Users/secret"),
+            "leaked path: {}",
+            error.message
+        );
+        assert!(
+            !error.message.contains("sqlite"),
+            "leaked detail: {}",
+            error.message
+        );
+        // A stable, safe, generic message instead.
+        assert_eq!(error.message, "An internal error occurred.");
     }
 
     #[tokio::test]

--- a/src-tauri/src/temporal.rs
+++ b/src-tauri/src/temporal.rs
@@ -15,7 +15,8 @@ use serde::Deserialize;
 use std::time::Instant;
 use tauri::State;
 
-use crate::ipc::{EmptyPayload, HostError, IpcRequest, IpcResponse, ipc_handle};
+use crate::ipc::{EmptyPayload, HostError, IpcRequest, IpcResponse};
+use crate::telemetry::command_envelope;
 use crate::worker::WorkerState;
 
 /// Namespaced + requestId-wrapped temporal state query.
@@ -24,11 +25,12 @@ pub async fn chrona_temporal_state_at(
     state: State<'_, WorkerState>,
     request: IpcRequest<StateAtArgs>,
 ) -> Result<IpcResponse<StateAtResult>, HostError> {
-    let IpcRequest {
-        request_id,
-        payload,
-    } = request;
-    Ok(ipc_handle(request_id, temporal_state_at_inner(state.engine(), payload)).await)
+    Ok(
+        command_envelope("chrona_temporal_state_at", request, |payload| {
+            temporal_state_at_inner(state.engine(), payload)
+        })
+        .await,
+    )
 }
 
 async fn temporal_state_at_inner(
@@ -57,11 +59,12 @@ pub async fn chrona_temporal_diff(
     state: State<'_, WorkerState>,
     request: IpcRequest<DiffArgs>,
 ) -> Result<IpcResponse<DiffSummary>, HostError> {
-    let IpcRequest {
-        request_id,
-        payload,
-    } = request;
-    Ok(ipc_handle(request_id, temporal_diff_inner(state.engine(), payload)).await)
+    Ok(
+        command_envelope("chrona_temporal_diff", request, |payload| {
+            temporal_diff_inner(state.engine(), payload)
+        })
+        .await,
+    )
 }
 
 async fn temporal_diff_inner(
@@ -104,11 +107,12 @@ pub async fn chrona_temporal_commit_changes(
     state: State<'_, WorkerState>,
     request: IpcRequest<CommitChangesRequest>,
 ) -> Result<IpcResponse<CommitChangesResponse>, HostError> {
-    let IpcRequest {
-        request_id,
-        payload,
-    } = request;
-    Ok(ipc_handle(request_id, commit_changes(state, payload)).await)
+    Ok(
+        command_envelope("chrona_temporal_commit_changes", request, |payload| {
+            commit_changes(state, payload)
+        })
+        .await,
+    )
 }
 
 #[derive(Debug, Deserialize)]
@@ -143,11 +147,12 @@ pub async fn chrona_temporal_list_commits(
     state: State<'_, WorkerState>,
     request: IpcRequest<ListCommitsPayload>,
 ) -> Result<IpcResponse<ListCommitsResponse>, HostError> {
-    let IpcRequest {
-        request_id,
-        payload,
-    } = request;
-    Ok(ipc_handle(request_id, list_commits(state, payload.branch)).await)
+    Ok(
+        command_envelope("chrona_temporal_list_commits", request, |payload| {
+            list_commits(state, payload.branch)
+        })
+        .await,
+    )
 }
 
 async fn list_commits_inner(
@@ -163,11 +168,12 @@ pub async fn chrona_temporal_create_branch(
     state: State<'_, WorkerState>,
     request: IpcRequest<CreateBranchRequest>,
 ) -> Result<IpcResponse<BranchInfo>, HostError> {
-    let IpcRequest {
-        request_id,
-        payload,
-    } = request;
-    Ok(ipc_handle(request_id, create_branch_inner(state.engine(), payload)).await)
+    Ok(
+        command_envelope("chrona_temporal_create_branch", request, |payload| {
+            create_branch_inner(state.engine(), payload)
+        })
+        .await,
+    )
 }
 
 async fn create_branch_inner(
@@ -186,11 +192,12 @@ pub async fn chrona_temporal_list_branches(
     state: State<'_, WorkerState>,
     request: IpcRequest<EmptyPayload>,
 ) -> Result<IpcResponse<ListBranchesResponse>, HostError> {
-    let request_id = request.request_id;
-    Ok(IpcResponse::ok(
-        request_id,
-        list_branches_inner(state.engine()).await,
-    ))
+    Ok(command_envelope(
+        "chrona_temporal_list_branches",
+        request,
+        |_payload| async move { Ok::<_, HostError>(list_branches_inner(state.engine()).await) },
+    )
+    .await)
 }
 
 async fn list_branches_inner(engine: &aideon_chrona::TemporalEngine) -> ListBranchesResponse {
@@ -203,11 +210,12 @@ pub async fn chrona_temporal_merge_branches(
     state: State<'_, WorkerState>,
     request: IpcRequest<MergeRequest>,
 ) -> Result<IpcResponse<MergeResponse>, HostError> {
-    let IpcRequest {
-        request_id,
-        payload,
-    } = request;
-    Ok(ipc_handle(request_id, merge_branches_inner(state.engine(), payload)).await)
+    Ok(
+        command_envelope("chrona_temporal_merge_branches", request, |payload| {
+            merge_branches_inner(state.engine(), payload)
+        })
+        .await,
+    )
 }
 
 async fn merge_branches_inner(
@@ -223,11 +231,12 @@ pub async fn chrona_temporal_topology_delta(
     state: State<'_, WorkerState>,
     request: IpcRequest<TopologyDeltaArgs>,
 ) -> Result<IpcResponse<TopologyDeltaResult>, HostError> {
-    let IpcRequest {
-        request_id,
-        payload,
-    } = request;
-    Ok(ipc_handle(request_id, topology_delta_inner(state.engine(), payload)).await)
+    Ok(
+        command_envelope("chrona_temporal_topology_delta", request, |payload| {
+            topology_delta_inner(state.engine(), payload)
+        })
+        .await,
+    )
 }
 
 async fn topology_delta_inner(
@@ -243,11 +252,12 @@ pub async fn praxis_metamodel_get(
     state: State<'_, WorkerState>,
     request: IpcRequest<EmptyPayload>,
 ) -> Result<IpcResponse<MetaModelDocument>, HostError> {
-    let request_id = request.request_id;
-    Ok(IpcResponse::ok(
-        request_id,
-        temporal_metamodel_get_inner(state.engine()).await,
-    ))
+    Ok(
+        command_envelope("praxis_metamodel_get", request, |_payload| async move {
+            Ok::<_, HostError>(temporal_metamodel_get_inner(state.engine()).await)
+        })
+        .await,
+    )
 }
 
 async fn temporal_metamodel_get_inner(engine: &aideon_chrona::TemporalEngine) -> MetaModelDocument {

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tauri::State;
 
-use crate::ipc::{EmptyPayload, HostError, IpcRequest, IpcResponse};
+use crate::ipc::{EmptyPayload, HostError, IpcRequest, IpcResponse, is_missing_snapshot_error};
 use crate::praxis_api::ScenarioSummary;
 use crate::telemetry::respond_with_request;
 use crate::worker::WorkerState;
@@ -272,10 +272,6 @@ fn default_templates() -> Vec<TemplatePayload> {
             ],
         },
     ]
-}
-
-fn is_missing_snapshot_error(message: &str) -> bool {
-    message.contains("os error 2") || message.contains("No such file")
 }
 
 fn load_templates() -> Result<Vec<TemplatePayload>, HostError> {

--- a/src-tauri/tests/internal/ipc_tests.rs
+++ b/src-tauri/tests/internal/ipc_tests.rs
@@ -26,6 +26,20 @@ fn ipc_response_ok_serializes_camel_case_envelope() {
 }
 
 #[test]
+fn missing_snapshot_error_is_recognised() {
+    // Absence of a derived snapshot is "no data yet", not a failure — one
+    // shared predicate recognises it so scene + workspace don't each re-detect.
+    assert!(is_missing_snapshot_error(
+        "io error: No such file or directory (os error 2)"
+    ));
+    assert!(is_missing_snapshot_error("open failed: os error 2"));
+    assert!(!is_missing_snapshot_error(
+        "permission denied (os error 13)"
+    ));
+    assert!(!is_missing_snapshot_error("invalid utf-8 in segment"));
+}
+
+#[test]
 fn ipc_response_err_serializes_stable_error_envelope() {
     let response: IpcResponse<()> = IpcResponse::err("req-2", HostError::invalid_input("bad"));
     let value = serde_json::to_value(&response).expect("serialize IpcResponse");


### PR DESCRIPTION
## What
Resolves #357 — deepen the host command seam. One `command_envelope` adapter now handles unpacking, `correlation_id`, telemetry, success wrapping, and error mapping; every host command delegates through it.

Built TDD (red→green→refactor), behaviour at the seam:
- **Error redaction (new):** internal/unclassified errors keep their stable code but get a generic external message (`"An internal error occurred."`) — raw detail logged only. Known domain errors keep their stable code **and** safe message (watchpoint honoured).
- **Dedup:** `is_missing_snapshot_error` lifted to one predicate in `ipc.rs`; copies in scene.rs + workspace.rs removed.
- **Collapse:** the three wirings (`ipc_handle`-direct, `respond_with_request`, inline `match{ok,err}`) → one. `respond_with_request` delegates to `command_envelope`; temporal (8) + praxis_api (6) repointed; **`ipc_handle` deleted**. This closed an internal-error **leak** on temporal/praxis_api (their old paths didn't redact).

## Tests (TDD)
New behaviour tests in `telemetry_tests` + `ipc_tests`: success + correlation echo, known-error code preserved (not redacted), internal-error redaction (no path/detail leak), missing-snapshot recognised. Wrapper signatures unchanged, so existing wrapper + direct-inner tests are untouched. **72 host lib tests green; clippy -D warnings + fmt clean.**

## Notes
`CommandContext` dropped from the issue sketch (handler closes over `State`; a context object can earn its keep later). "No 4th pattern" guard test skipped — a grep check is brittle; `ipc_handle`'s deletion makes `command_envelope` the structural default.

Closes #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDfBw4QGj4s3FPG7GYTBhX