### PR TITLE
test(host): genuine TDD — M0 commands through the real IPC dispatch seam

### DIFF
--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -224,3 +224,7 @@ fn log_level() -> LevelFilter {
 #[cfg(test)]
 #[path = "../tests/internal/app_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "../tests/internal/host_dispatch_tests.rs"]
+mod host_dispatch_tests;

--- a/src-tauri/tests/internal/host_dispatch_tests.rs
+++ b/src-tauri/tests/internal/host_dispatch_tests.rs
@@ -1,0 +1,120 @@
+//! Host command tests through the REAL IPC dispatch pipeline.
+//!
+//! These cross the same seam a renderer crosses — `invoke(command, { request })`
+//! routed through `generate_handler!` and the Tauri invoke pipeline — rather than
+//! calling the command function directly. They prove routing, body→`IpcRequest`
+//! deserialisation, command execution, and envelope serialisation as one path.
+//! (Per-window capability denial is NOT exercised here: `mock_context` does not
+//! load the real capability set — that decision is Tier-2 / spike #329.)
+
+use aideon_chrona::TemporalEngine;
+use serde_json::{Value, json};
+use tauri::ipc::{CallbackFn, InvokeBody};
+use tauri::test::{INVOKE_KEY, get_ipc_response, mock_builder, mock_context, noop_assets};
+use tauri::webview::InvokeRequest;
+use tauri::{App, WebviewWindow, WebviewWindowBuilder};
+
+use crate::worker::WorkerState;
+
+fn invoke_url() -> tauri::Url {
+    if cfg!(any(windows, target_os = "android")) {
+        "http://tauri.localhost"
+    } else {
+        "tauri://localhost"
+    }
+    .parse()
+    .expect("invoke url")
+}
+
+/// Build a mock app that registers the M0 host commands and manages a real
+/// `WorkerState`, plus a `main` webview to dispatch against.
+async fn dispatch_app() -> (
+    App<tauri::test::MockRuntime>,
+    WebviewWindow<tauri::test::MockRuntime>,
+) {
+    let engine = TemporalEngine::new().await.expect("engine init");
+    let state = WorkerState::new(engine);
+    let app = mock_builder()
+        .invoke_handler(tauri::generate_handler![
+            crate::health::system_worker_health
+        ])
+        .manage(state)
+        .build(mock_context(noop_assets()))
+        .expect("build mock app");
+    let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
+        .build()
+        .expect("build webview");
+    (app, webview)
+}
+
+/// Dispatch a command the way the renderer does: `invoke(cmd, { request: { requestId, payload } })`.
+fn dispatch(
+    webview: &WebviewWindow<tauri::test::MockRuntime>,
+    cmd: &str,
+    payload: Value,
+) -> Result<Value, Value> {
+    let response = get_ipc_response(
+        webview,
+        InvokeRequest {
+            cmd: cmd.to_string(),
+            callback: CallbackFn(0),
+            error: CallbackFn(1),
+            url: invoke_url(),
+            body: InvokeBody::Json(json!({ "request": { "requestId": "d1", "payload": payload } })),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    );
+    response.map(|body| body.deserialize::<Value>().expect("deserialize ok body"))
+}
+
+#[tokio::test]
+async fn worker_health_round_trips_through_real_ipc_dispatch() {
+    let (_app, webview) = dispatch_app().await;
+
+    let value = dispatch(&webview, "system_worker_health", json!({})).expect("dispatch ok");
+
+    // The renderer-facing envelope, produced by the real invoke pipeline.
+    assert_eq!(value["status"], "ok");
+    assert_eq!(value["requestId"], "d1");
+    assert!(
+        value.get("result").is_some(),
+        "health result present: {value}"
+    );
+}
+
+#[tokio::test]
+async fn unknown_command_is_rejected_by_dispatch() {
+    let (_app, webview) = dispatch_app().await;
+
+    // Only reachable through real dispatch — a direct fn call cannot test routing.
+    let error = dispatch(&webview, "command_that_does_not_exist", json!({}))
+        .expect_err("unknown command must be rejected, not silently succeed");
+
+    assert!(!error.is_null(), "rejection carries a reason: {error}");
+}
+
+#[tokio::test]
+async fn malformed_request_body_is_rejected_by_dispatch() {
+    let (_app, webview) = dispatch_app().await;
+
+    // Body missing the `request` envelope the command expects — the boundary must
+    // reject it (deserialisation error), not run the command on garbage.
+    let response = get_ipc_response(
+        &webview,
+        InvokeRequest {
+            cmd: "system_worker_health".to_string(),
+            callback: CallbackFn(0),
+            error: CallbackFn(1),
+            url: invoke_url(),
+            body: InvokeBody::Json(json!({ "unexpected": "shape" })),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    );
+
+    assert!(
+        response.is_err(),
+        "malformed body must fail at the boundary, got ok: {response:?}"
+    );
+}


### PR DESCRIPTION
## What
Makes the M0 host boundary genuinely TDD'd — tested through the **public interface a renderer crosses** (real `invoke` dispatch), not by calling command fns directly.

The existing host tests do `mock_app()` then call the command fn directly — never exercising routing, arg-deserialisation, or the envelope serialise path. These dispatch through `tauri::test::get_ipc_response`, matching the renderer's real `invoke(cmd, { request: { requestId, payload } })` shape.

Behaviours (TDD, one at a time):
- `system_worker_health` **round-trips** — ok envelope, echoed `requestId`, result present.
- an **unknown command is rejected** by routing (only reachable via real dispatch).
- a **malformed body** (missing the `request` envelope) fails at the boundary, not on garbage.

**75 host lib tests green; clippy -D warnings + fmt clean.**

## Resolves the #329 spike (empirically)
`get_ipc_response` dispatch **works in tests** → routing / arg-deser / envelope are **Tier-1**. But `mock_context(noop_assets())` does **not** load the real capability set, so per-window capability **denial** is **Tier-2** (real WebView). This is the spike's answer.

Establishes the Tier-1 host-boundary harness (ADR-0040 / #319) on existing M0 commands; the workspace lifecycle commands (#290) plug into the same harness when built.

Refs #319 #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDfBw4QGj4s3FPG7GYTBhX