### PR TITLE
chore(docs): clear auto-fixable + config markdownlint residual

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -23,5 +23,6 @@
   "MD013": false,
   "MD024": false,
   "MD029": false,
-  "MD033": false
+  "MD033": false,
+  "MD036": false
 }

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -15,3 +15,4 @@ docs/**/generated/
 package-lock.json
 pnpm-lock.yaml
 **/.cache/
+CHANGELOG.md

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,3 +1,5 @@
+# Aideon Desktop shell — build tasks
+
 ## Stage 0 – Baseline and assumptions
 
 Before starting, the agent should assume:

--- a/docs/02-standards/ADR-FORMAT.md
+++ b/docs/02-standards/ADR-FORMAT.md
@@ -12,7 +12,7 @@ boundaries, or security posture must be reviewed against [`DESIGN-GOVERNANCE.md`
 
 ## Header block
 
-```
+```text
 # ADR-XXXX: Title
 
 - Status: Proposed | Accepted | Superseded

--- a/docs/03-design/README.md
+++ b/docs/03-design/README.md
@@ -18,7 +18,7 @@ written in is fixed by the [Documentation Standard](../02-standards/DOCUMENTATIO
 Start with the design spine, then follow the area that answers your question. Each area below is a folder of small
 single-topic files indexed by its own README (Documentation Standard §4).
 
-```
+```text
 overview & axioms  →  design/ (this README + the spine files)
 the workspace      →  desktop-first-workspace/
 the product unit   →  artefacts/

--- a/docs/03-design/artefacts/explanation-surfaces.md
+++ b/docs/03-design/artefacts/explanation-surfaces.md
@@ -24,7 +24,7 @@ A user moves from a summary result to the underlying entity, from the entity to 
 to its evidence, and from evidence to a valid action — **without losing orientation and without switching mental
 models**. If the user must break the conceptual frame to follow the evidence, the explanation surface is incomplete.
 
-```
+```text
 Artefact result
   └─▶ Inspector: properties + explanation + provenance
         └─▶ Evidence: contributing entities, relationships, paths

--- a/docs/03-design/the-shell.md
+++ b/docs/03-design/the-shell.md
@@ -8,7 +8,7 @@ The shell has four permanent jobs: keep orientation stable, keep context visible
 make action available without forcing the user to hunt for it. The regions' proportions vary by surface; their roles
 never change.
 
-```
+```text
 ┌────────────────────────────────────────────────────────────┐
 │  Toolbar   workspace identity · time + scenario · search · status │
 ├─────────┬────────────────────────────────────┬─────────────┤

--- a/docs/03-design/ux/accepted-work-ux.md
+++ b/docs/03-design/ux/accepted-work-ux.md
@@ -22,7 +22,7 @@ lifecycle — it does not invent its own.
 Every module uses the **same** status vocabulary. There is no per-module polling protocol and no private status set; a
 user who learns the vocabulary once reads every module's work the same way.
 
-```
+```text
 Submit
   └─▶ accepted   (system acknowledged the work, assigned a runId)
         ├─▶ running     (progress events streaming)

--- a/docs/03-design/ux/drill-down.md
+++ b/docs/03-design/ux/drill-down.md
@@ -16,7 +16,7 @@ The path follows information foraging (Pirolli & Card, _Information Foraging_, 1
 **scent** — a cue that tells the user the evidence they want lies one step away, and in which direction — and
 **progressive disclosure** keeps the dense detail behind that step rather than crowding the summary.
 
-```
+```text
 Artefact result
   └─▶ Inspector: properties + explanation + provenance
         └─▶ Evidence: contributing entities, relationships, paths

--- a/docs/04-contracts/accepted-work-and-events/run-and-step-lifecycle.md
+++ b/docs/04-contracts/accepted-work-and-events/run-and-step-lifecycle.md
@@ -35,7 +35,7 @@ A run moves through a set of statuses; terminal statuses are final.
 
 ## Normal, retry, and failure flows
 
-```
+```text
 accepted → running → [step.pending → step.running → step.succeeded]+ → succeeded
 step.running → step.retrying → step.running → ... → step.succeeded | step.failed
 running → step.failed → failed

--- a/docs/04-contracts/accepted-work-and-events/run-ledger.md
+++ b/docs/04-contracts/accepted-work-and-events/run-ledger.md
@@ -8,7 +8,7 @@ window. It is owned by [Continuum](../../05-modules/continuum/snapshot-store-and
 
 ## Storage location
 
-```
+```text
 <workspace>/
 └── ops/
     └── runs/

--- a/docs/04-contracts/temporal-and-scenario/hlc-encoding.md
+++ b/docs/04-contracts/temporal-and-scenario/hlc-encoding.md
@@ -10,7 +10,7 @@ robust to clock skew.
 
 ## The packing
 
-```
+```text
  63                    12 11          0
  ┌──────────────────────┬─────────────┐
  │  physical_micros     │   counter   │

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -26,7 +26,7 @@ order in the root [`CLAUDE.md`](../../CLAUDE.md). Documentation is authoritative
 
 ## Repository shape
 
-```
+```text
 /
 ├── CONTEXT.md                         ← domain glossary (exists; read first)
 ├── CLAUDE.md                          ← precedence order and agent guidance

--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -26,7 +26,7 @@ where it lives as data.
 
 ## Layout
 
-```
+```text
 docs/data/
   README.md                 # this file — the operational note
   schema-governance.md       # how to add/deprecate a type or relationship
@@ -82,16 +82,21 @@ The metamodel's UUIDs are **minted by the compiler, never hand-authored** — se
    than rewriting an existing one, so the seed reads as a history. Bump the `version` field per the
    [version bump rules](#version-bump-rules) and record the change in [base/CHANGELOG.md](./base/CHANGELOG.md).
 3. **Dry-run the importer** against a scratch datastore to validate without writing:
+
    ```sh
    cargo aideon_xtask import-dataset --dataset docs/data/base/baseline.yaml \
        --datastore /tmp/praxis --dry-run
    ```
+
    The dry-run applies the dataset to an in-memory store, so validation mirrors runtime behaviour exactly.
+
 4. **Write it** once the dry-run is clean:
+
    ```sh
    cargo aideon_xtask import-dataset --dataset docs/data/base/baseline.yaml \
        --datastore /tmp/praxis
    ```
+
 5. **Run the dataset tests** to confirm the guardrail counts still hold (below). A change that shifts a count without
    updating the expectation is a failing test, by design.
 

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -31,7 +31,7 @@ a proxy boundary, and a thin typed-IPC seam to the host. Engines are gated by li
 contributes nothing. Nothing durable lives in the renderer; everything it shows is a cache of host truth read at a
 [viewpoint](../../CONTEXT.md), and everything it changes is a command.
 
-```
+```text
 ┌──────────────────────────────────────────────────────────┐
 │  Aideon Desktop shell (one shell, four regions)            │
 │  ┌──────────────┬───────────────────────────┬───────────┐ │

--- a/docs/frontend/data-fetching.md
+++ b/docs/frontend/data-fetching.md
@@ -20,7 +20,7 @@ of library.
 A query key **must** identify the read fully, and the read is taken at a viewpoint, so the key includes the viewpoint
 ([state-architecture.md](./state-architecture.md)). The canonical key shape is:
 
-```
+```text
 [ <surface>, <resource>, <params>, viewpoint ]
 ```
 

--- a/docs/frontend/praxis-contributions/DESIGN.md
+++ b/docs/frontend/praxis-contributions/DESIGN.md
@@ -46,7 +46,7 @@ are avoided.
 Server-state reads key on the surface, the resource, its params, and the full viewpoint
 ([data-fetching.md](../data-fetching.md)):
 
-```
+```text
 [ "praxis", "graphSlice", { scope }, viewpoint ]
 [ "praxis", "artefactResult", { artefactId }, viewpoint ]
 [ "praxis", "metaModel", {}, viewpoint ]

--- a/docs/frontend/shell.md
+++ b/docs/frontend/shell.md
@@ -39,7 +39,7 @@ platform supplies each from `src/platform/`:
 | `content`    | The dominant content region that renders the **active surface instance**. Each surface composes platform- and engine-contributed widgets per its own fixed or user-editable composition contract.                                           | `PlatformContent`                   | `SidebarInset` + `Resizable` |
 | `inspector`  | Selection-driven contextual details and forms                                                                                                                                                                                               | `PlatformInspector`                 | `Resizable` + `Panel`        |
 
-```
+```text
 ┌────────────────────────────────────────────────────────────────┐
 │ Toolbar (global chrome + viewpoint + layout-preset/temporal)     │
 ├──────────────┬───────────────────────────┬─────────────────────┤


### PR DESCRIPTION
## What

Follows the prettier prose-wrap PR (#785) by clearing the markdownlint tail that needs **no prose authoring** — everything here is `--fix`, a safe mechanical edit, or a config decision.

## Changes

- **`markdownlint --fix`** — MD031 blanks-around-fences (4).
- **MD040 fenced-code-language (15)** — added `text` to bare fences; every one is an ASCII box/diagram block, so `text` is the correct (non-highlighting) language. Line-targeted, not a blanket rewrite.
- **MD041** — added an H1 title to `TASKS.md`.
- **Config — disable MD036** (emphasis-as-heading): the repo intentionally uses bold sub-labels (`**Docs**` / `**Tests**` / `**Code**` in `TASKS.md` and build docs); MD036 false-positives on these. Joins MD024/MD029/MD033 already disabled.
- Aligned `.markdownlintignore` with `.markdownlint.json`'s `ignores` (`CHANGELOG.md`, release-please-owned) so local runs match Codacy.

## Result

markdownlint residual across our docs: **~60 → 0** (the only remaining hits are in the generated, ignored `CHANGELOG.md`). What's left in Codacy after this is genuine content authoring — none of which is auto-fixable, so it's out of scope here.

## Verification

`pnpm run ci` green (0 lint errors, tests pass, format clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)