### PR TITLE
chore(codacy): exclude vendored agent/claude skill trees from analysis

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,10 @@
+# Codacy repository configuration.
+#
+# Exclude vendored, third-party agent-skill definitions from analysis: the
+# `.agents/` and `.claude/` trees are synced from upstream skill packages, not
+# authored here (they are also prettier-ignored, see .prettierignore). Linting
+# them generated thousands of issues (Bandit/markdownlint/…) against code we do
+# not own and cannot fix without diverging from upstream on the next sync.
+exclude_paths:
+  - '.agents/**'
+  - '.claude/**'


### PR DESCRIPTION
## What

Tell Codacy to ignore the vendored skill trees — `.agents/**` and `.claude/**` — via `.codacy.yaml` `exclude_paths`.

## Why

These trees are synced from upstream skill packages, not authored in this repo (they're already `.prettierignore`d for the same reason). Codacy was analysing them and reporting **thousands** of issues — Bandit (Python security), markdownlint, etc. — against third-party code we can't fix without diverging from upstream on the next skill sync.

## Impact

The repo backlog was ~4,365 after the markdown work; the large majority sit under `.agents/`/`.claude/`. Excluding them leaves Codacy focused on **our** code, so the grade reflects issues we can actually act on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)