### PR TITLE
fix(security): pin third-party actions to SHA + clear test-only High findings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup pnpm
         if: matrix.language == 'javascript-typescript'
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node
         if: matrix.language == 'javascript-typescript'
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup Rust toolchain
         if: matrix.language == 'rust'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
 
       - name: Linux GUI deps (required for Tauri Rust compilation)
         if: matrix.language == 'rust'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - uses: actions/setup-node@v5
         with:
@@ -70,7 +70,7 @@ jobs:
             pkg-config libglib2.0-dev libgtk-3-dev libayatana-appindicator3-dev \
             librsvg2-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: rustfmt, clippy
 
@@ -104,7 +104,7 @@ jobs:
             pkg-config libglib2.0-dev libgtk-3-dev libayatana-appindicator3-dev \
             librsvg2-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - uses: actions/setup-node@v5
         with:
@@ -115,7 +115,7 @@ jobs:
       # (keyed on Cargo.lock + rustc, caches the workspace target at repo root).
       # The previous manual cache pointed at src-tauri/target — the wrong dir,
       # since src-tauri is a workspace member and builds go to the root /target.
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
 
       - run: pnpm install --frozen-lockfile
 
@@ -129,7 +129,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - uses: actions/setup-node@v5
         with:
@@ -144,7 +144,7 @@ jobs:
             librsvg2-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev \
             webkit2gtk-driver xvfb
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
 
       - name: Cache tauri-driver install
         id: cache-tauri-driver-webdriver
@@ -180,7 +180,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - uses: actions/setup-node@v5
         with:
@@ -195,7 +195,7 @@ jobs:
             librsvg2-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev \
             webkit2gtk-driver xvfb
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
 
       - name: Cache tauri-driver install
         id: cache-tauri-driver-tier2
@@ -225,14 +225,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Release Please
         id: release
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json

--- a/.github/workflows/repo-maintenance.yml
+++ b/.github/workflows/repo-maintenance.yml
@@ -14,7 +14,7 @@ jobs:
       actions: write # Required to delete workflow runs / logs / artifacts
     steps:
       - name: Delete workflow runs
-        uses: viascom/github-maintenance-action@v0.2.0
+        uses: viascom/github-maintenance-action@100787bdd54a85f51117c429b6b4d93a6a52eaf6 # v0.2.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           retention_days: 7

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -54,7 +54,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Get pnpm store directory
         id: pnpm-store-app
@@ -87,7 +87,7 @@ jobs:
       # (keyed on Cargo.lock + rustc, per-target). The previous manual cache of
       # src-tauri/target cached the wrong dir (workspace builds go to /target).
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           targets: ${{ matrix.target }}
           components: rustfmt, clippy
@@ -107,7 +107,7 @@ jobs:
 
       - name: Import Apple codesign certificates
         if: matrix.os == 'macos-latest' && inputs.publish && env.APPLE_CERT_PRESENT == 'true'
-        uses: apple-actions/import-codesign-certs@v7
+        uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7
         with:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}

--- a/crates/continuum/tests/internal/lib_tests.rs
+++ b/crates/continuum/tests/internal/lib_tests.rs
@@ -4,6 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
 fn file_store_put_get_roundtrip() {
+    // nosemgrep: rust.lang.security.temp-dir.temp-dir -- test-only scratch dir, not a security path
     let base = std::env::temp_dir().join(format!(
         "aideon-test-{}",
         SystemTime::now()

--- a/src-tauri/tests/internal/scene_tests.rs
+++ b/src-tauri/tests/internal/scene_tests.rs
@@ -65,6 +65,7 @@ async fn canvas_scene_returns_shapes() {
 #[tokio::test]
 async fn canvas_layout_roundtrips() {
     let _guard = env_lock().lock().await;
+    // nosemgrep: rust.lang.security.temp-dir.temp-dir -- test-only scratch dir, not a security path
     let base = std::env::temp_dir().join(format!(
         "aideon-test-{}",
         SystemTime::now()
@@ -72,6 +73,7 @@ async fn canvas_layout_roundtrips() {
             .unwrap()
             .as_millis()
     ));
+    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- env::set_var/remove_var are unsafe in Rust 2024; serialized by env_lock() in tests
     unsafe {
         std::env::set_var("AIDEON_TEST_DATA_DIR", base.to_string_lossy().to_string());
     }
@@ -110,6 +112,7 @@ async fn canvas_layout_roundtrips() {
     assert_eq!(loaded, Some(payload));
 
     let _ = fs::remove_dir_all(base);
+    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- env::set_var/remove_var are unsafe in Rust 2024; serialized by env_lock() in tests
     unsafe {
         std::env::remove_var("AIDEON_TEST_DATA_DIR");
     }
@@ -118,8 +121,10 @@ async fn canvas_layout_roundtrips() {
 #[tokio::test]
 async fn canvas_get_layout_returns_none_when_missing() {
     let _guard = env_lock().lock().await;
+    // nosemgrep: rust.lang.security.temp-dir.temp-dir -- test-only scratch dir, not a security path
     let base = std::env::temp_dir().join("aideon-missing-snapshot");
     let _ = fs::remove_dir_all(&base);
+    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- env::set_var/remove_var are unsafe in Rust 2024; serialized by env_lock() in tests
     unsafe {
         std::env::set_var("AIDEON_TEST_DATA_DIR", base.to_string_lossy().to_string());
     }
@@ -136,6 +141,7 @@ async fn canvas_get_layout_returns_none_when_missing() {
     assert!(response.is_none());
 
     let _ = fs::remove_dir_all(base);
+    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- env::set_var/remove_var are unsafe in Rust 2024; serialized by env_lock() in tests
     unsafe {
         std::env::remove_var("AIDEON_TEST_DATA_DIR");
     }
@@ -144,6 +150,7 @@ async fn canvas_get_layout_returns_none_when_missing() {
 #[tokio::test]
 async fn graph_layout_roundtrips() {
     let _guard = env_lock().lock().await;
+    // nosemgrep: rust.lang.security.temp-dir.temp-dir -- test-only scratch dir, not a security path
     let base = std::env::temp_dir().join(format!(
         "aideon-graph-{}",
         SystemTime::now()
@@ -151,6 +158,7 @@ async fn graph_layout_roundtrips() {
             .unwrap()
             .as_millis()
     ));
+    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- env::set_var/remove_var are unsafe in Rust 2024; serialized by env_lock() in tests
     unsafe {
         std::env::set_var("AIDEON_TEST_DATA_DIR", base.to_string_lossy().to_string());
     }
@@ -183,6 +191,7 @@ async fn graph_layout_roundtrips() {
     assert_eq!(loaded, Some(payload));
 
     let _ = fs::remove_dir_all(base);
+    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- env::set_var/remove_var are unsafe in Rust 2024; serialized by env_lock() in tests
     unsafe {
         std::env::remove_var("AIDEON_TEST_DATA_DIR");
     }
@@ -193,6 +202,7 @@ async fn praxis_scene_wrappers_cover_ipc_surface() {
     let _guard = env_lock().lock().await;
     let dir = tempfile::tempdir().expect("tempdir");
     let base = dir.path().to_path_buf();
+    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- env::set_var/remove_var are unsafe in Rust 2024; serialized by env_lock() in tests
     unsafe {
         std::env::set_var("AIDEON_TEST_DATA_DIR", base.to_string_lossy().to_string());
     }
@@ -269,6 +279,7 @@ async fn praxis_scene_wrappers_cover_ipc_surface() {
     assert_eq!(response.status, "ok");
     assert!(!response.result.unwrap_or_default().is_empty());
 
+    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- env::set_var/remove_var are unsafe in Rust 2024; serialized by env_lock() in tests
     unsafe {
         std::env::remove_var("AIDEON_TEST_DATA_DIR");
     }

--- a/src-tauri/tests/internal/workspace_tests.rs
+++ b/src-tauri/tests/internal/workspace_tests.rs
@@ -51,6 +51,7 @@ async fn projects_list_wraps_request_id() {
 #[tokio::test]
 async fn templates_list_is_bootstrapped_and_wrapped() {
     let _guard = env_lock().lock().await;
+    // nosemgrep: rust.lang.security.temp-dir.temp-dir -- test-only scratch dir, not a security path
     let base = std::env::temp_dir().join(format!(
         "aideon-templates-list-{}",
         SystemTime::now()
@@ -58,6 +59,7 @@ async fn templates_list_is_bootstrapped_and_wrapped() {
             .unwrap()
             .as_millis()
     ));
+    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- env::set_var/remove_var are unsafe in Rust 2024; serialized by env_lock() in tests
     unsafe {
         std::env::set_var("AIDEON_TEST_DATA_DIR", base.to_string_lossy().to_string());
     }
@@ -82,6 +84,7 @@ async fn templates_list_is_bootstrapped_and_wrapped() {
     assert!(!response.result.unwrap().is_empty());
 
     let _ = fs::remove_dir_all(base);
+    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- env::set_var/remove_var are unsafe in Rust 2024; serialized by env_lock() in tests
     unsafe {
         std::env::remove_var("AIDEON_TEST_DATA_DIR");
     }
@@ -90,6 +93,7 @@ async fn templates_list_is_bootstrapped_and_wrapped() {
 #[tokio::test]
 async fn templates_save_roundtrips() {
     let _guard = env_lock().lock().await;
+    // nosemgrep: rust.lang.security.temp-dir.temp-dir -- test-only scratch dir, not a security path
     let base = std::env::temp_dir().join(format!(
         "aideon-templates-{}",
         SystemTime::now()
@@ -97,6 +101,7 @@ async fn templates_save_roundtrips() {
             .unwrap()
             .as_millis()
     ));
+    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- env::set_var/remove_var are unsafe in Rust 2024; serialized by env_lock() in tests
     unsafe {
         std::env::set_var("AIDEON_TEST_DATA_DIR", base.to_string_lossy().to_string());
     }
@@ -132,6 +137,7 @@ async fn templates_save_roundtrips() {
     assert_eq!(response.status, "ok");
 
     let _ = fs::remove_dir_all(base);
+    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- env::set_var/remove_var are unsafe in Rust 2024; serialized by env_lock() in tests
     unsafe {
         std::env::remove_var("AIDEON_TEST_DATA_DIR");
     }


### PR DESCRIPTION
Clears the remaining **High**-severity Codacy/Opengrep security findings (the tier surfaced after #789 cleared the 12 critical + postcss medium).

## Supply-chain: pin third-party actions to commit SHA
Per GitHub's hardening guide (`third-party-action-not-pinned-to-commit-sha`), every third-party action is now pinned to a full commit SHA with a version comment, across all workflows:

| Action | Pinned SHA |
|---|---|
| `pnpm/action-setup@v6` | `0ebf471` |
| `actions-rust-lang/setup-rust-toolchain@v1` | `166cdcf` |
| `apple-actions/import-codesign-certs@v7` | `5142e02` |
| `googleapis/release-please-action@v5` | `45996ed` |
| `viascom/github-maintenance-action@v0.2.0` | `100787b` |

`github/codeql-action/*` left on tags — GitHub-owned and not flagged.

## Test-only Rust findings — justified `nosemgrep`
All in `tests/internal/` harnesses:
- **`temp_dir`** — unique per-test scratch dirs (and one deliberately-missing path); never security-sensitive paths.
- **`unsafe`** — `env::set_var`/`remove_var` are `unsafe` fns in Rust 2024; mutations are serialized by `env_lock()` and confined to test setup/teardown.

## Left deliberately
`glib@0.18.5` (medium) — pinned deep in Tauri's Linux GTK stack; can't move to 0.20 without Tauri bumping `gtk`. Upstream's call.

## Verification
- `pnpm run ci` green (lint, typecheck, tests, format — TS/React + Rust).
- All workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)